### PR TITLE
Force `focus-follows-mouse` for contained `vaadin-list-box`

### DIFF
--- a/src/vaadin-dropdown-menu.html
+++ b/src/vaadin-dropdown-menu.html
@@ -428,6 +428,9 @@ This program is available under Apache License Version 2.0, available at https:/
             this._menuElement.addEventListener('selected-changed', e => this._updateValueSlot());
             this._menuElement.addEventListener('keydown', e => this._onKeyDownInside(e));
             this._menuElement.addEventListener('click', e => this.opened = false);
+            if (this._menuElement.focusFollowsMouse !== undefined) {
+              this._menuElement.focusFollowsMouse = true;
+            }
           }
         }
 


### PR DESCRIPTION
connects to https://github.com/vaadin/vaadin-list-box/issues/14

depends on https://github.com/vaadin/vaadin-list-mixin/pull/43
depends on https://github.com/vaadin/vaadin-list-box/pull/46

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-dropdown-menu/166)
<!-- Reviewable:end -->