### PR TITLE
fix(bower): move vaadin-list-box and vaadin-item to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,6 @@
 
 [<img src="https://raw.githubusercontent.com/vaadin/vaadin-select/master/screenshot.gif" width="220" alt="Screenshot of vaadin-select">](https://vaadin.com/components/vaadin-select)
 
-**Note:** [`<vaadin-list-box>`](https://github.com/vaadin/vaadin-list-box) component used in the above example should be installed and imported separately.
-
 ## Installation
 
 The Vaadin components are distributed as Bower and npm packages.

--- a/bower.json
+++ b/bower.json
@@ -32,6 +32,8 @@
     "vaadin-control-state-mixin": "vaadin/vaadin-control-state-mixin#^2.1.1",
     "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.3.2",
     "vaadin-text-field": "vaadin/vaadin-text-field#^2.1.1",
+    "vaadin-list-box": "vaadin/vaadin-list-box#^1.1.0",
+    "vaadin-item": "vaadin/vaadin-item#^2.1.0",
     "vaadin-overlay": "vaadin/vaadin-overlay#^3.2.0",
     "vaadin-lumo-styles": "vaadin/vaadin-lumo-styles#^1.1.0",
     "vaadin-material-styles": "vaadin/vaadin-material-styles#^1.1.0",
@@ -45,9 +47,7 @@
     "webcomponentsjs": "^1.0.0",
     "web-component-tester": "^6.1.5",
     "vaadin-demo-helpers": "vaadin/vaadin-demo-helpers#^2.2.0",
-    "vaadin-button": "vaadin/vaadin-button#^2.1.0",
-    "vaadin-list-box": "vaadin/vaadin-list-box#^1.1.0",
-    "vaadin-item": "vaadin/vaadin-item#^2.1.0"
+    "vaadin-button": "vaadin/vaadin-button#^2.1.0"
   },
   "resolutions": {
     "vaadin-element-mixin": "^2.0.0"


### PR DESCRIPTION
Fixes #176 

Note: `vaadin-select` still does not enforce you to use `vaadin-list-box`, so for the advanced users it is still possible to use import from `src` without getting the latter imported.
Someone might find this useful when working on a custom theme, e.g. using custom list-box.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-select/177)
<!-- Reviewable:end -->
