### PR TITLE
test: check keyboard search for closed select

### DIFF
--- a/test/select-test.html
+++ b/test/select-test.html
@@ -403,6 +403,7 @@
         });
 
         it('should select items when alphanumeric keys are pressed', () => {
+          select.opened = false;
           expect(select._menuElement.selected).to.be.equal(2);
           keyDownChar(input, 'o');
           keyDownChar(input, 'p');


### PR DESCRIPTION
Fixes #189 

Looks like the test wasn't correct but only failed in IE11 for some reason.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-select/190)
<!-- Reviewable:end -->
