### PR TITLE
demo: simplify demos by using template more

### DIFF
--- a/demo/select-basic-demos.html
+++ b/demo/select-basic-demos.html
@@ -10,7 +10,7 @@
     <vaadin-demo-snippet id="select-list-box-template" when-defined="vaadin-select">
       <template preserve-content>
         <vaadin-select></vaadin-select>
-        <template id="selectTemplate" preserve-content>
+        <template id="items-for-select" preserve-content>
           <vaadin-list-box>
             <vaadin-item>Jose</vaadin-item>
             <vaadin-item>Manolo</vaadin-item>
@@ -19,7 +19,7 @@
         </template>
         <script>
           window.addDemoReadyListener('#select-list-box-template', function(document) {
-            const template = document.getElementById('selectTemplate');
+            const template = document.getElementById('items-for-select');
             document.querySelector('vaadin-select').renderer = function(root) {
               if (!root.firstChild) {
                 root.appendChild(template.content.cloneNode(true));
@@ -81,7 +81,7 @@
         <vaadin-select label="Label" placeholder="Placeholder"></vaadin-select>
         <vaadin-select label="Disabled" disabled></vaadin-select>
         <vaadin-select label="Read-only" readonly value="Option one"></vaadin-select>
-        <template id="basicTemplate" preserve-content>
+        <template id="items-for-select" preserve-content>
           <vaadin-list-box>
             <vaadin-item>Option one</vaadin-item>
             <vaadin-item>Option two</vaadin-item>
@@ -89,7 +89,7 @@
         </template>
 
         <vaadin-select label="Required" required></vaadin-select>
-        <template id="requiredTemplate" preserve-content>
+        <template id="items-for-required-select" preserve-content>
           <vaadin-list-box>
             <vaadin-item value="" disabled>Select an option</vaadin-item>
             <hr>
@@ -109,13 +109,13 @@
               };
             };
 
-            const basicTemplate = document.getElementById('basicTemplate');
+            const basicTemplate = document.getElementById('items-for-select');
             const basicSelects = document.querySelectorAll('vaadin-select:not([required])');
             for (let i = 0; i < basicSelects.length; i++) {
               basicSelects[i].renderer = makeStaticTemplateRenderer(basicTemplate);
             }
 
-            const requiredTemplate = document.getElementById('requiredTemplate');
+            const requiredTemplate = document.getElementById('items-for-required-select');
             const requiredSelect = document.querySelector('vaadin-select[required]');
             requiredSelect.renderer = makeStaticTemplateRenderer(requiredTemplate);
           });
@@ -130,7 +130,7 @@
     <vaadin-demo-snippet id="select-list-box-custom-label" when-defined="vaadin-select">
       <template preserve-content>
         <vaadin-select placeholder="Language"></vaadin-select>
-        <template id="selectTemplate" preserve-content>
+        <template id="items-for-select" preserve-content>
           <vaadin-list-box>
             <vaadin-item>Other</vaadin-item>
             <vaadin-item label="ES">Spanish</vaadin-item>
@@ -140,7 +140,7 @@
         </template>
         <script>
           window.addDemoReadyListener('#select-list-box-custom-label', function(document) {
-            const template = document.getElementById('selectTemplate');
+            const template = document.getElementById('items-for-select');
             document.querySelector('vaadin-select').renderer = function(root) {
               if (!root.firstChild) {
                 root.appendChild(template.content.cloneNode(true));

--- a/demo/select-basic-demos.html
+++ b/demo/select-basic-demos.html
@@ -7,26 +7,17 @@
     </style>
 
     <h3>Basic usage</h3>
-    <vaadin-demo-snippet id="select-list-box-template" when-defined="vaadin-select">
+    <vaadin-demo-snippet id="select-list-box-basic" when-defined="vaadin-select">
       <template preserve-content>
-        <vaadin-select></vaadin-select>
-        <template id="items-for-select" preserve-content>
-          <vaadin-list-box>
-            <vaadin-item>Jose</vaadin-item>
-            <vaadin-item>Manolo</vaadin-item>
-            <vaadin-item>Pedro</vaadin-item>
-          </vaadin-list-box>
-        </template>
-        <script>
-          window.addDemoReadyListener('#select-list-box-template', function(document) {
-            const template = document.getElementById('items-for-select');
-            document.querySelector('vaadin-select').renderer = function(root) {
-              if (!root.firstChild) {
-                root.appendChild(template.content.cloneNode(true));
-              }
-            };
-          });
-        </script>
+        <vaadin-select>
+          <template>
+            <vaadin-list-box>
+              <vaadin-item>Jose</vaadin-item>
+              <vaadin-item>Manolo</vaadin-item>
+              <vaadin-item>Pedro</vaadin-item>
+            </vaadin-list-box>
+          </template>
+        </vaadin-select>
       </template>
     </vaadin-demo-snippet>
 
@@ -57,69 +48,46 @@
       </template>
     </vaadin-demo-snippet>
 
-    <h3>Defining content with Polymer templates</h3>
-    <p>
-      When defining a template element as a child the select, the template is parsed as a Polymer template and used for rendering the content. This way you can also use Polymer data binding in the template.
-    </p>
-    <vaadin-demo-snippet id="select-list-box-polymer-template">
-      <template preserve-content>
-        <vaadin-select>
-          <template>
-            <vaadin-list-box>
-              <vaadin-item>Jose</vaadin-item>
-              <vaadin-item>Manolo</vaadin-item>
-              <vaadin-item>Pedro</vaadin-item>
-            </vaadin-list-box>
-          </template>
-        </vaadin-select>
-      </template>
-    </vaadin-demo-snippet>
-
     <h3>Configuring the select</h3>
     <vaadin-demo-snippet id="select-list-box-configuring" when-defined="vaadin-select">
       <template preserve-content>
-        <vaadin-select label="Label" placeholder="Placeholder"></vaadin-select>
-        <vaadin-select label="Disabled" disabled></vaadin-select>
-        <vaadin-select label="Read-only" readonly value="Option one"></vaadin-select>
-        <template id="items-for-select" preserve-content>
-          <vaadin-list-box>
-            <vaadin-item>Option one</vaadin-item>
-            <vaadin-item>Option two</vaadin-item>
-          </vaadin-list-box>
-        </template>
+        <vaadin-select label="Label" placeholder="Placeholder">
+          <template>
+            <vaadin-list-box>
+              <vaadin-item>Option one</vaadin-item>
+              <vaadin-item>Option two</vaadin-item>
+            </vaadin-list-box>
+          </template>
+        </vaadin-select>
 
-        <vaadin-select label="Required" required></vaadin-select>
-        <template id="items-for-required-select" preserve-content>
-          <vaadin-list-box>
-            <vaadin-item value="" disabled>Select an option</vaadin-item>
-            <hr>
-            <vaadin-item value="1">Option one</vaadin-item>
-            <vaadin-item value="2">Option two</vaadin-item>
-            <vaadin-item value="3">Option three</vaadin-item>
-            <vaadin-item value="4">Option four</vaadin-item>
-          </vaadin-list-box>
-        </template>
-        <script>
-          window.addDemoReadyListener('#select-list-box-configuring', function(document) {
-            const makeStaticTemplateRenderer = function(template) {
-              return function(root) {
-                if (!root.firstChild) {
-                  root.appendChild(template.content.cloneNode(true));
-                }
-              };
-            };
+        <vaadin-select label="Disabled" disabled value="Option one">
+          <template>
+            <vaadin-list-box>
+              <vaadin-item>Option one</vaadin-item>
+            </vaadin-list-box>
+          </template>
+        </vaadin-select>
 
-            const basicTemplate = document.getElementById('items-for-select');
-            const basicSelects = document.querySelectorAll('vaadin-select:not([required])');
-            for (let i = 0; i < basicSelects.length; i++) {
-              basicSelects[i].renderer = makeStaticTemplateRenderer(basicTemplate);
-            }
+        <vaadin-select label="Read-only" readonly value="Option one">
+          <template>
+            <vaadin-list-box>
+              <vaadin-item>Option one</vaadin-item>
+            </vaadin-list-box>
+          </template>
+        </vaadin-select>
 
-            const requiredTemplate = document.getElementById('items-for-required-select');
-            const requiredSelect = document.querySelector('vaadin-select[required]');
-            requiredSelect.renderer = makeStaticTemplateRenderer(requiredTemplate);
-          });
-        </script>
+        <vaadin-select label="Required" required>
+          <template>
+            <vaadin-list-box>
+              <vaadin-item value="" disabled>Select an option</vaadin-item>
+              <hr>
+              <vaadin-item value="1">Option one</vaadin-item>
+              <vaadin-item value="2">Option two</vaadin-item>
+              <vaadin-item value="3">Option three</vaadin-item>
+              <vaadin-item value="4">Option four</vaadin-item>
+            </vaadin-list-box>
+          </template>
+        </vaadin-select>
       </template>
     </vaadin-demo-snippet>
 
@@ -129,25 +97,16 @@
     </p>
     <vaadin-demo-snippet id="select-list-box-custom-label" when-defined="vaadin-select">
       <template preserve-content>
-        <vaadin-select placeholder="Language"></vaadin-select>
-        <template id="items-for-select" preserve-content>
-          <vaadin-list-box>
-            <vaadin-item>Other</vaadin-item>
-            <vaadin-item label="ES">Spanish</vaadin-item>
-            <vaadin-item label="FI">Finnish</vaadin-item>
-            <vaadin-item label="EN">English</vaadin-item>
-          </vaadin-list-box>
-        </template>
-        <script>
-          window.addDemoReadyListener('#select-list-box-custom-label', function(document) {
-            const template = document.getElementById('items-for-select');
-            document.querySelector('vaadin-select').renderer = function(root) {
-              if (!root.firstChild) {
-                root.appendChild(template.content.cloneNode(true));
-              }
-            };
-          });
-        </script>
+        <vaadin-select placeholder="Language">
+          <template>
+            <vaadin-list-box>
+              <vaadin-item>Other</vaadin-item>
+              <vaadin-item label="ES">Spanish</vaadin-item>
+              <vaadin-item label="FI">Finnish</vaadin-item>
+              <vaadin-item label="EN">English</vaadin-item>
+            </vaadin-list-box>
+          </template>
+        </vaadin-select>
       </template>
     </vaadin-demo-snippet>
 

--- a/demo/select-basic-demos.html
+++ b/demo/select-basic-demos.html
@@ -6,12 +6,36 @@
       }
     </style>
 
-    <h3>Basic Usage</h3>
-    <vaadin-demo-snippet id="select-list-box-basic" when-defined="vaadin-select">
+    <h3>Basic usage</h3>
+    <vaadin-demo-snippet id="select-list-box-template" when-defined="vaadin-select">
+      <template preserve-content>
+        <vaadin-select></vaadin-select>
+        <template id="selectTemplate" preserve-content>
+          <vaadin-list-box>
+            <vaadin-item>Jose</vaadin-item>
+            <vaadin-item>Manolo</vaadin-item>
+            <vaadin-item>Pedro</vaadin-item>
+          </vaadin-list-box>
+        </template>
+        <script>
+          window.addDemoReadyListener('#select-list-box-template', function(document) {
+            const template = document.getElementById('selectTemplate');
+            document.querySelector('vaadin-select').renderer = function(root) {
+              if (!root.firstChild) {
+                root.appendChild(template.content.cloneNode(true));
+              }
+            };
+          });
+        </script>
+      </template>
+    </vaadin-demo-snippet>
+
+    <h3>Dynamically creating the contents</h3>
+    <vaadin-demo-snippet id="select-list-box-dynamic" when-defined="vaadin-select">
       <template preserve-content>
         <vaadin-select></vaadin-select>
         <script>
-          window.addDemoReadyListener('#select-list-box-basic', function(document) {
+          window.addDemoReadyListener('#select-list-box-dynamic', function(document) {
             document.querySelector('vaadin-select').renderer = function(root) {
               // Check if there is a list-box generated with the previous renderer call to update its content instead of recreation
               if (root.firstChild) {
@@ -33,9 +57,9 @@
       </template>
     </vaadin-demo-snippet>
 
-    <h3>Defining Content with Polymer Templates</h3>
+    <h3>Defining content with Polymer templates</h3>
     <p>
-      The content can be provided using the HTML template.
+      When defining a template element as a child the select, the template is parsed as a Polymer template and used for rendering the content. This way you can also use Polymer data binding in the template.
     </p>
     <vaadin-demo-snippet id="select-list-box-polymer-template">
       <template preserve-content>
@@ -51,107 +75,76 @@
       </template>
     </vaadin-demo-snippet>
 
-    <h3>Configuring the Select</h3>
+    <h3>Configuring the select</h3>
     <vaadin-demo-snippet id="select-list-box-configuring" when-defined="vaadin-select">
       <template preserve-content>
         <vaadin-select label="Label" placeholder="Placeholder"></vaadin-select>
         <vaadin-select label="Disabled" disabled></vaadin-select>
         <vaadin-select label="Read-only" readonly value="Option one"></vaadin-select>
+        <template id="basicTemplate" preserve-content>
+          <vaadin-list-box>
+            <vaadin-item>Option one</vaadin-item>
+            <vaadin-item>Option two</vaadin-item>
+          </vaadin-list-box>
+        </template>
+
         <vaadin-select label="Required" required></vaadin-select>
+        <template id="requiredTemplate" preserve-content>
+          <vaadin-list-box>
+            <vaadin-item value="" disabled>Select an option</vaadin-item>
+            <hr>
+            <vaadin-item value="1">Option one</vaadin-item>
+            <vaadin-item value="2">Option two</vaadin-item>
+            <vaadin-item value="3">Option three</vaadin-item>
+            <vaadin-item value="4">Option four</vaadin-item>
+          </vaadin-list-box>
+        </template>
         <script>
           window.addDemoReadyListener('#select-list-box-configuring', function(document) {
-            const appendItems = function(listBox, items) {
-              items.forEach(function(row) {
-                const item = window.document.createElement('vaadin-item');
-                item.textContent = row.textContent;
-                if (row.value) {
-                  item.setAttribute('value', row.value);
+            const makeStaticTemplateRenderer = function(template) {
+              return function(root) {
+                if (!root.firstChild) {
+                  root.appendChild(template.content.cloneNode(true));
                 }
-                listBox.appendChild(item);
-              });
+              };
             };
 
-            document.querySelector('vaadin-select[placeholder]').renderer = function(root) {
-              if (root.firstChild) {
-                return;
-              }
-              const listBox = window.document.createElement('vaadin-list-box');
-              appendItems(listBox, [{textContent: 'Option one'}, {textContent: 'Option two'}]);
-              root.appendChild(listBox);
-            };
+            const basicTemplate = document.getElementById('basicTemplate');
+            const basicSelects = document.querySelectorAll('vaadin-select:not([required])');
+            for (let i = 0; i < basicSelects.length; i++) {
+              basicSelects[i].renderer = makeStaticTemplateRenderer(basicTemplate);
+            }
 
-            document.querySelector('vaadin-select[disabled]').renderer = function(root) {
-              if (root.firstChild) {
-                return;
-              }
-              const listBox = window.document.createElement('vaadin-list-box');
-              appendItems(listBox, [{textContent: 'Option one'}]);
-              root.appendChild(listBox);
-            };
-
-            document.querySelector('vaadin-select[readonly]').renderer = function(root) {
-              if (root.firstChild) {
-                return;
-              }
-              const listBox = window.document.createElement('vaadin-list-box');
-              appendItems(listBox, [{textContent: 'Option one'}]);
-              root.appendChild(listBox);
-            };
-
-            document.querySelector('vaadin-select[required]').renderer = function(root) {
-              if (root.firstChild) {
-                return;
-              }
-              const listBox = window.document.createElement('vaadin-list-box');
-              // un-selectable <vaadin-item> to highlight required state
-              const select = window.document.createElement('vaadin-item');
-              select.textContent = 'Select an option';
-              select.setAttribute('disabled', '');
-              select.setAttribute('value', '');
-              listBox.appendChild(select);
-              // <hr> divider
-              const divider = window.document.createElement('hr');
-              listBox.appendChild(divider);
-              appendItems(listBox, [
-                {value: '1', textContent: 'Option one'},
-                {value: '2', textContent: 'Option two'},
-                {value: '3', textContent: 'Option three'},
-                {value: '4', textContent: 'Option four'}
-              ]);
-              root.appendChild(listBox);
-            };
+            const requiredTemplate = document.getElementById('requiredTemplate');
+            const requiredSelect = document.querySelector('vaadin-select[required]');
+            requiredSelect.renderer = makeStaticTemplateRenderer(requiredTemplate);
           });
         </script>
       </template>
     </vaadin-demo-snippet>
 
-    <h3>Customize the Label of Selected Value</h3>
+    <h3>Customize the label of selected value</h3>
     <p>
         By setting the <code>label</code> attribute of inner vaadin-items you will be able to change the visual representation of the selected value in the input part.
     </p>
     <vaadin-demo-snippet id="select-list-box-custom-label" when-defined="vaadin-select">
       <template preserve-content>
         <vaadin-select placeholder="Language"></vaadin-select>
+        <template id="selectTemplate" preserve-content>
+          <vaadin-list-box>
+            <vaadin-item>Other</vaadin-item>
+            <vaadin-item label="ES">Spanish</vaadin-item>
+            <vaadin-item label="FI">Finnish</vaadin-item>
+            <vaadin-item label="EN">English</vaadin-item>
+          </vaadin-list-box>
+        </template>
         <script>
           window.addDemoReadyListener('#select-list-box-custom-label', function(document) {
+            const template = document.getElementById('selectTemplate');
             document.querySelector('vaadin-select').renderer = function(root) {
-              if (root.firstChild) {
-                return;
+              if (!root.firstChild) {
+                root.appendChild(template.content.cloneNode(true));
               }
-              const listBox = window.document.createElement('vaadin-list-box');
-              const items = [
-                {label: '', textContent: 'Other'},
-                {label: 'ES', textContent: 'Spanish'},
-                {label: 'FI', textContent: 'Finnish'},
-                {label: 'EN', textContent: 'English'}
-              ];
-              items.forEach(function(row) {
-                const item = window.document.createElement('vaadin-item');
-                item.textContent = row.textContent;
-                item.setAttribute('label', row.label);
-                listBox.appendChild(item);
-              });
-              root.appendChild(listBox);
             };
           });
         </script>

--- a/demo/select-validation-demos.html
+++ b/demo/select-validation-demos.html
@@ -11,17 +11,18 @@
       <template preserve-content>
         <iron-form>
           <form method="post">
-            <vaadin-select name="title" label="Title" error-message="Please choose the option closest to your profession" required></vaadin-select>
-            <template id="items-for-select" preserve-content>
-              <vaadin-list-box>
-                <vaadin-item value="">Select your title</vaadin-item>
-                <hr>
-                <vaadin-item value="sales">Account manager</vaadin-item>
-                <vaadin-item value="design">Designer</vaadin-item>
-                <vaadin-item value="marketing">Marketing manager</vaadin-item>
-                <vaadin-item value="dev">Developer</vaadin-item>
-              </vaadin-list-box>
-            </template>
+            <vaadin-select name="title" label="Title" error-message="Please choose the option closest to your profession" required>
+              <template>
+                <vaadin-list-box>
+                  <vaadin-item value="">Select your title</vaadin-item>
+                  <hr>
+                  <vaadin-item value="sales">Account manager</vaadin-item>
+                  <vaadin-item value="design">Designer</vaadin-item>
+                  <vaadin-item value="marketing">Marketing manager</vaadin-item>
+                  <vaadin-item value="dev">Developer</vaadin-item>
+                </vaadin-list-box>
+              </template>
+            </vaadin-select>
             <vaadin-button>Submit</vaadin-button>
           </form>
         </iron-form>
@@ -41,13 +42,6 @@
             button.addEventListener('click', function() {
               form.submit();
             });
-
-            const template = document.getElementById('items-for-select');
-            document.querySelector('vaadin-select').renderer = function(root) {
-              if (!root.firstChild) {
-                root.appendChild(template.content.cloneNode(true));
-              }
-            };
           });
         </script>
       </template>

--- a/demo/select-validation-demos.html
+++ b/demo/select-validation-demos.html
@@ -12,7 +12,7 @@
         <iron-form>
           <form method="post">
             <vaadin-select name="title" label="Title" error-message="Please choose the option closest to your profession" required></vaadin-select>
-            <template id="selectTemplate" preserve-content>
+            <template id="items-for-select" preserve-content>
               <vaadin-list-box>
                 <vaadin-item value="">Select your title</vaadin-item>
                 <hr>
@@ -42,7 +42,7 @@
               form.submit();
             });
 
-            const template = document.getElementById('selectTemplate');
+            const template = document.getElementById('items-for-select');
             document.querySelector('vaadin-select').renderer = function(root) {
               if (!root.firstChild) {
                 root.appendChild(template.content.cloneNode(true));

--- a/demo/select-validation-demos.html
+++ b/demo/select-validation-demos.html
@@ -6,12 +6,22 @@
       }
     </style>
 
-    <h3>Using as a Form Field</h3>
+    <h3>Using as a form field</h3>
     <vaadin-demo-snippet id="select-validation" when-defined="vaadin-select">
       <template preserve-content>
         <iron-form>
           <form method="post">
             <vaadin-select name="title" label="Title" error-message="Please choose the option closest to your profession" required></vaadin-select>
+            <template id="selectTemplate" preserve-content>
+              <vaadin-list-box>
+                <vaadin-item value="">Select your title</vaadin-item>
+                <hr>
+                <vaadin-item value="sales">Account manager</vaadin-item>
+                <vaadin-item value="design">Designer</vaadin-item>
+                <vaadin-item value="marketing">Marketing manager</vaadin-item>
+                <vaadin-item value="dev">Developer</vaadin-item>
+              </vaadin-list-box>
+            </template>
             <vaadin-button>Submit</vaadin-button>
           </form>
         </iron-form>
@@ -32,38 +42,11 @@
               form.submit();
             });
 
-            const items = [
-              {value: 'sales', textContent: 'Account manager'},
-              {value: 'design', textContent: 'Designer'},
-              {value: 'marketing', textContent: 'Marketing manager'},
-              {value: 'dev', textContent: 'Developer'},
-            ];
-
+            const template = document.getElementById('selectTemplate');
             document.querySelector('vaadin-select').renderer = function(root) {
-              if (root.firstChild) {
-                return;
+              if (!root.firstChild) {
+                root.appendChild(template.content.cloneNode(true));
               }
-
-              const listBox = window.document.createElement('vaadin-list-box');
-
-              const select = window.document.createElement('vaadin-item');
-              select.textContent = 'Select your title';
-              select.setAttribute('value', '');
-              listBox.appendChild(select);
-
-              const divider = window.document.createElement('hr');
-              listBox.appendChild(divider);
-
-              items.forEach(function(row) {
-                const item = window.document.createElement('vaadin-item');
-                item.textContent = row.textContent;
-                if (row.value) {
-                  item.setAttribute('value', row.value);
-                }
-                listBox.appendChild(item);
-              });
-
-              root.appendChild(listBox);
             };
           });
         </script>


### PR DESCRIPTION
Make the basic demos shorter and easier to understand at a glance by using native `<template>` element (without Polymer template parsing) within renderer to avoid having a lot of JS just to create static DOM elements.

This can be further simplified later if we add a new feature which allows the user to specify this kind of non-Polymer `<template>` as a child of the `vaadin-select` without having to manually define a renderer method. It would work basically the same way as Polymer template now, but we would need some new attribute for the template to specify that it should not be parsed as a Polymer template (so that this kind of usage is future proof and doesn't advocate using Polymer only features).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-select/203)
<!-- Reviewable:end -->
