### PR TITLE
docs: add JSDoc for attributes [skip ci]

### DIFF
--- a/src/vaadin-select.html
+++ b/src/vaadin-select.html
@@ -220,6 +220,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
             /**
              * The error message to display when the select value is invalid
+             * @attr {string} error-message
              * @type {string}
              */
             errorMessage: {


### PR DESCRIPTION
Connected to vaadin/vaadin-core#257

Note, this is a PR for `2.3` branch. When cherry-picking it to master, we need to also include `helperText` property.