### PR TITLE
ci: support skipping GitHub actions [skip ci]

### DIFF
--- a/.github/workflows/sauce.yml
+++ b/.github/workflows/sauce.yml
@@ -5,6 +5,7 @@ on: [push]
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
+    if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
 
     steps:
     - uses: actions/checkout@v2
@@ -23,6 +24,7 @@ jobs:
 
   visual-tests:
     runs-on: ubuntu-latest
+    if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
See https://github.community/t/github-actions-does-not-respect-skip-ci/17325

Note, the `github.event.commits.*.message` is only available for the `push` event, but not for the the `pull_request` 😕 