### PR TITLE
chore: add JSDoc for custom events [skip ci]

### DIFF
--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -13,17 +13,17 @@ export type SelectRenderer = (root: HTMLElement, select?: SelectElement) => void
 /**
  * Fired when the `opened` property changes.
  */
-export type SelectOpenedChanged = CustomEvent<{ value: boolean; path: 'opened' }>;
+export type SelectOpenedChanged = CustomEvent<{ value: boolean }>;
 
 /**
  * Fired when the `invalid` property changes.
  */
-export type SelectInvalidChanged = CustomEvent<{ value: boolean; path: 'invalid' }>;
+export type SelectInvalidChanged = CustomEvent<{ value: boolean }>;
 
 /**
  * Fired when the `value` property changes.
  */
-export type SelectValueChanged = CustomEvent<{ value: string; path: 'value' }>;
+export type SelectValueChanged = CustomEvent<{ value: string }>;
 
 export interface SelectElementEventMap {
   'opened-changed': SelectOpenedChanged;

--- a/src/vaadin-select.d.ts
+++ b/src/vaadin-select.d.ts
@@ -98,6 +98,10 @@ import { SelectEventMap, SelectRenderer } from './interfaces';
  *
  * Note: the `theme` attribute value set on `<vaadin-select>` is
  * propagated to the internal themable components listed above.
+ *
+ * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
+ * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
+ * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  */
 declare class SelectElement extends ElementMixin(ControlStateMixin(ThemableMixin(HTMLElement))) {
   readonly focusElement: HTMLElement;

--- a/src/vaadin-select.js
+++ b/src/vaadin-select.js
@@ -121,6 +121,10 @@ document.head.appendChild($_documentContainer.content);
  * Note: the `theme` attribute value set on `<vaadin-select>` is
  * propagated to the internal themable components listed above.
  *
+ * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
+ * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
+ * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
+ *
  * @extends HTMLElement
  * @mixes ElementMixin
  * @mixes ControlStateMixin


### PR DESCRIPTION
1. Added `@fires` annotations to enable VS Code lit-plugin code completion support.
2. Removed `path` from events typings as Polymer-specific and generally unused.