### PR TITLE
chore: align JSDoc, add change event [skip ci]

### DIFF
--- a/src/vaadin-select.d.ts
+++ b/src/vaadin-select.d.ts
@@ -99,6 +99,7 @@ import { SelectEventMap, SelectRenderer } from './interfaces';
  * Note: the `theme` attribute value set on `<vaadin-select>` is
  * propagated to the internal themable components listed above.
  *
+ * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.

--- a/src/vaadin-select.js
+++ b/src/vaadin-select.js
@@ -121,6 +121,7 @@ document.head.appendChild($_documentContainer.content);
  * Note: the `theme` attribute value set on `<vaadin-select>` is
  * propagated to the internal themable components listed above.
  *
+ * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.


### PR DESCRIPTION
Added a `change` event to align with the [API docs](https://cdn.vaadin.com/vaadin-select/3.0.0-alpha1/#/elements/vaadin-select#events).