### PR TITLE
fix: restore select focus on fullscreen dropdown close (#3120)

### DIFF
--- a/src/vaadin-select.html
+++ b/src/vaadin-select.html
@@ -576,13 +576,9 @@ This program is available under Apache License Version 2.0, available at https:/
             this._setPosition();
             window.addEventListener('scroll', this._boundSetPosition, true);
           } else if (wasOpened) {
-            if (this._phone) {
-              this._setFocused(false);
-            } else {
-              this.focusElement.focus();
-              if (this._openedWithFocusRing) {
-                this.focusElement.setAttribute('focus-ring', '');
-              }
+            this.focusElement.focus();
+            if (this._openedWithFocusRing) {
+              this.focusElement.setAttribute('focus-ring', '');
             }
             this.validate();
             window.removeEventListener('scroll', this._boundSetPosition, true);

--- a/test/select-test.html
+++ b/test/select-test.html
@@ -673,20 +673,20 @@
           });
         }
 
-        it('should remove focused state from the input on closing the overlay if phone', () => {
+        it('should restore focused state to the input on closing the overlay if phone', () => {
           select._phone = true;
           menu.selected = 1;
-          expect(select.hasAttribute('focused')).to.be.false;
-          expect(input.hasAttribute('focused')).to.be.false;
+          expect(select.hasAttribute('focused')).to.be.true;
+          expect(input.hasAttribute('focused')).to.be.true;
         });
 
-        it('should not focus the input on closing the overlay if phone', () => {
+        it('should focus the input on closing the overlay if phone', () => {
           const focusedSpy = sinon.spy();
           select.focusElement.focus = focusedSpy;
 
           select._phone = true;
           menu.selected = 1;
-          expect(focusedSpy).not.to.be.called;
+          expect(focusedSpy.called).to.be.true;
         });
 
         it('should focus the input before moving the focus to next selectable element', () => {


### PR DESCRIPTION
Backport https://github.com/vaadin/web-components/pull/3120 for V14