### PR TITLE
fix: prevent initial validation for select

### DIFF
--- a/src/vaadin-select.html
+++ b/src/vaadin-select.html
@@ -521,11 +521,10 @@ This program is available under Apache License Version 2.0, available at https:/
             this.focusElement.setAttribute('has-value', '');
           }
 
-          // Skip validation for the initial empty string value
-          if (value === '' && oldValue === undefined) {
-            return;
+          // Validate only if `value` changes after initialization.
+          if (oldValue !== undefined) {
+            this.validate();
           }
-          this.validate();
         }
 
         /**

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,8 +1,12 @@
 {
+  "parserOptions": {
+    "ecmaVersion": 8
+  },
   "globals": {
     "WCT": false,
     "describe": false,
     "beforeEach": false,
+    "afterEach": false,
     "fixture": false,
     "flush": false,
     "it": false,

--- a/test/select-test.html
+++ b/test/select-test.html
@@ -903,5 +903,45 @@
         expect(select._overlayElement.getAttribute('theme')).to.equal('foo');
       });
     });
+
+    describe('initial validation', () => {
+      let select, validateSpy;
+
+      function nextRender(element) {
+        return new Promise(resolve => {
+          Polymer.RenderStatus.afterNextRender(element, resolve);
+        });
+      }
+    
+      beforeEach(() => {
+        select = document.createElement('vaadin-select');
+        validateSpy = sinon.spy(select, 'validate');
+      });
+
+      afterEach(() => {
+        select.remove();
+      });
+
+      it('should not validate by default', async() => {
+        document.body.appendChild(select);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
+      });
+
+      it('should not validate when the field has an initial value', async() => {
+        select.value = 'value';
+        document.body.appendChild(select);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
+      });
+
+      it('should not validate when the field has an initial value and invalid', async() => {
+        select.value = 'value';
+        select.invalid = true;
+        document.body.appendChild(select);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
+      });
+    });
   </script>
 </body>


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

The PR prevents the initial validation that could previously take place when select was initially provided with a non-empty value.

Referred PR : https://github.com/vaadin/web-components/pull/4174

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

