### PR TITLE
revert: "fix: prevent initial validation"

### DIFF
--- a/src/vaadin-select.html
+++ b/src/vaadin-select.html
@@ -521,10 +521,11 @@ This program is available under Apache License Version 2.0, available at https:/
             this.focusElement.setAttribute('has-value', '');
           }
 
-          // Validate only if `value` changes after initialization.
-          if (oldValue !== undefined) {
-            this.validate();
+          // Skip validation for the initial empty string value
+          if (value === '' && oldValue === undefined) {
+            return;
           }
+          this.validate();
         }
 
         /**

--- a/test/validation.html
+++ b/test/validation.html
@@ -14,38 +14,5 @@
 
 <body>
   <script>
-  describe('initial validation', () => {
-    let select, validateSpy;
-
-    beforeEach(() => {
-      select = document.createElement('vaadin-select');
-      validateSpy = sinon.spy(select, 'validate');
-    });
-
-    afterEach(() => {
-      select.remove();
-    });
-
-    it('should not validate by default', async() => {
-      document.body.appendChild(select);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
-    });
-
-    it('should not validate when the field has an initial value', async() => {
-      select.value = 'value';
-      document.body.appendChild(select);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
-    });
-
-    it('should not validate when the field has an initial value and invalid', async() => {
-      select.value = 'value';
-      select.invalid = true;
-      document.body.appendChild(select);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
-    });
-  });
   </script>
 </body>


### PR DESCRIPTION
Reverted https://github.com/vaadin/vaadin-select/pull/296/. It was decided not to backport the PRs preventing initial validation as it is a breaking change.

Part of https://github.com/vaadin/web-components/issues/5763